### PR TITLE
search function now ignores spaces on search query and anime title

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -399,8 +399,9 @@ const imageUrlToBase64 = async (url) => {
 };
 
 const searchAnime = async (query) => {
-    let queryLowerCase = query.toLowerCase();
-    const res = directoryAnimes.filter(x => x.title.toLowerCase().includes(queryLowerCase));
+    
+    let queryLowerCase = query.toLowerCase().replace(/\s/g, '');
+    const res = data.filter(x => x.title.toLowerCase().replace(/\s/g, '').includes(queryLowerCase));
 
     return res.map(doc => ({
         id: doc.id || null,


### PR DESCRIPTION
Every time you enter a text without spaces as a query, the search function doesn't return the correct anime.

![Screenshot_99](https://user-images.githubusercontent.com/41026227/109892055-fe4f8780-7c68-11eb-8d16-2234942e55cf.png)

Now it just ignores spaces completely
![Screenshot_100](https://user-images.githubusercontent.com/41026227/109892083-0c9da380-7c69-11eb-929f-23bdab68290c.png)


