### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: ktor_app
+    container_name: aruppi-api-dev
     ports:
       - "8080:8080"
     env_file:
       - .env
-    networks:
-      - app-network
-
-networks:
-  app-network:
-    driver: bridge


### PR DESCRIPTION
Removes unnecessary network clause to avoid conflicts, a default network will be provided by the engine.

Renames container_name to a more proper names